### PR TITLE
[fix] : Remove architecture-specific optimization flag from FFmpeg build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN ./configure \
     --disable-outdevs \
     \
     # ── Compiler Optimizations ── \
-    --extra-cflags="-O2 -march=armv8-a" \
+    --extra-cflags="-O2" \
     \
     && make -j$(nproc) \
     && make install \


### PR DESCRIPTION
[![ci](https://github.com/maulik-mk/mp.ii-worker/actions/workflows/ci.yml/badge.svg)](https://github.com/maulik-mk/mp.ii-worker/actions/workflows/ci.yml)
---
This pull request makes a minor adjustment to the compiler optimization flags used during the build process in the `Dockerfile`. The change removes the architecture-specific flag from the `--extra-cflags` option, leaving only the general optimization flag.

* Build configuration: Removed the `-march=armv8-a` flag from `--extra-cflags`, so builds will now use only the `-O2` optimization without targeting a specific CPU architecture.
---
<img width="1279" height="170" alt="Screenshot" src="https://github.com/user-attachments/assets/ef53492b-9d65-4b34-afaa-f6ebed8e670e" />
