### PR TITLE
[fix] : ensure ffmpeg test script always specifies output file

### DIFF
--- a/test/ffmpeg.test.sh
+++ b/test/ffmpeg.test.sh
@@ -118,6 +118,7 @@ run_transcode_test() {
     log_info "Starting transcoding process (Memory Limit: ${CONTAINER_MEM_LIMIT})..."
     
     # Run FFmpeg in Docker
+    # First 10 seconds of the video only
     docker run --rm \
         --memory="${CONTAINER_MEM_LIMIT}" \
         --cpus="${CONTAINER_CPU_LIMIT}" \
@@ -132,7 +133,6 @@ run_transcode_test() {
         -filter_threads 1 \
         -vf "scale=1280:720" \
         -c:v libx264 -preset ultrafast -b:v 2800k \
-        # First 10 seconds of the video only
         -t 10 \
         -movflags +faststart \
         "/output/$(basename "${output_file}")"


### PR DESCRIPTION
[![CI](https://github.com/maulik-mk/mp.ii-worker/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/maulik-mk/mp.ii-worker/actions/workflows/ci.yml)
---

> This commit fixes a bug in the ffmpeg test script where a comment inside a multi-line command caused the output file argument to be omitted. The script now correctly passes the output file to ffmpeg, ensuring the transcoding test runs as intended and prevents the "At least one output file must be specified" error.

---
This pull request makes a minor update to the `run_transcode_test()` function in `test/ffmpeg.test.sh`, clarifying that only the first 10 seconds of the video are processed during transcoding. The main change is moving the comment about processing the first 10 seconds to directly above the relevant Docker command for better code clarity.

* Comment about processing only the first 10 seconds of the video moved above the Docker command in `run_transcode_test()` for improved clarity. [[1]](diffhunk://#diff-217d210649036a921110cbd739432763a6ee16d933580cdbcd80ff5ba0c73137R121) [[2]](diffhunk://#diff-217d210649036a921110cbd739432763a6ee16d933580cdbcd80ff5ba0c73137L135)

Comment : https://github.com/maulik-mk/mp.ii-worker/issues/6#issue-3953279502