### PR TITLE
[ HotFix ] : v0.3.1 remove x265 film tune

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,19 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      # 2. Extract Dockerfile VERSION
+      # 2. Extract Dockerfile VERSION and create Floating Minor Version
       - name: Read Dockerfile VERSION
         id: docker_version
         run: |
+          # Extract the exact version (e.g., "0.3.1")
           VERSION=$(grep -E '^ARG VERSION=' Dockerfile | cut -d '=' -f2 | tr -d '"')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Found Dockerfile VERSION=$VERSION"
-          if [[ "$VERSION" =~ \.0$ ]]; then
-            echo "IS_MAJOR_MINOR=true" >> $GITHUB_ENV
-          else
-            echo "IS_MAJOR_MINOR=false" >> $GITHUB_ENV
-          fi
+          
+          # Extract the minor floating version (e.g., "0.3" from "0.3.1")
+          MINOR_VERSION=$(echo $VERSION | cut -d. -f1,2)
+          echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
+          echo "Floating Minor Version=$MINOR_VERSION"
 
       # 3. Set Build Date
       - name: Set Build Date
@@ -50,35 +51,19 @@ jobs:
         id: docker_labels
         run: |
           echo "Extracting labels from Dockerfile..."
-          # Remove leading LABEL and combine into single line (multi-line support)
           LABELS=$(grep '^LABEL ' Dockerfile | sed 's/^LABEL //' | tr '\n' ' ')
-          # Replace ARG placeholders with ENV values
           LABELS="${LABELS//\${VERSION}/${{ env.VERSION }}}"
           LABELS="${LABELS//\${BUILD_DATE}/${{ env.BUILD_DATE }}}"
           echo "DOCKER_LABELS=$LABELS" >> $GITHUB_ENV
           echo "Extracted labels: $LABELS"
 
-      # 5. Check if Docker image VERSION exists in GHCR
-      - name: Check if Docker image VERSION exists
-        if: github.ref == 'refs/heads/main' && env.IS_MAJOR_MINOR == 'true'
-        id: check_version
-        run: |
-          EXISTING_TAG=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://ghcr.io/v2/${{ github.repository }}/tags/list" | jq -r '.tags[]?' | grep "^${{ env.VERSION }}$" || true)
-          echo "EXISTING_TAG=$EXISTING_TAG" >> $GITHUB_ENV
-          if [ "$EXISTING_TAG" = "${{ env.VERSION }}" ]; then
-            echo "Docker image VERSION=${{ env.VERSION }} already exists. Skipping build/push."
-          else
-            echo "Docker image VERSION=${{ env.VERSION }} is new. Will build/push."
-          fi
-
-      # 6. Set up Docker Buildx
+      # 5. Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 7. Build Docker image (only if new VERSION)
+      # 6. Build Docker image
       - name: Build and Load Docker Image
-        if: github.ref == 'refs/heads/main' && env.EXISTING_TAG == '' && env.IS_MAJOR_MINOR == 'true'
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -89,41 +74,44 @@ jobs:
           labels: ${{ env.DOCKER_LABELS }}
           tags: |
             worker-ffmpeg:${{ env.VERSION }}
+            worker-ffmpeg:${{ env.MINOR_VERSION }}
             worker-ffmpeg:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 8. Log in to GHCR
+      # 7. Log in to GHCR
       - name: Log in to GitHub Container Registry
-        if: github.ref == 'refs/heads/main' && env.EXISTING_TAG == '' && env.IS_MAJOR_MINOR == 'true'
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 9. Download Test Asset
+      # 8. Download Test Asset
       - name: Download Test Asset
         run: .github/scripts/download_test_video.sh
 
-      # 10. Run Test Suite
+      # 9. Run Test Suite
       - name: Run Test Suite
         run: .github/scripts/run_tests.sh
 
-      # 11. Push Docker image to GHCR (only if new VERSION)
+      # 10. Push Docker image to GHCR with all tags
       - name: Push to GHCR
-        if: github.ref == 'refs/heads/main' && env.EXISTING_TAG == '' && env.IS_MAJOR_MINOR == 'true'
+        if: github.ref == 'refs/heads/main'
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository }}
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
-          # Tag images
+          # Apply the exact patch tag, the floating minor tag, and the latest/sha tags
           docker tag worker-ffmpeg:${{ env.VERSION }} $IMAGE_ID:${{ env.VERSION }}
+          docker tag worker-ffmpeg:${{ env.MINOR_VERSION }} $IMAGE_ID:${{ env.MINOR_VERSION }}
           docker tag worker-ffmpeg:latest $IMAGE_ID:latest
           docker tag worker-ffmpeg:latest $IMAGE_ID:${{ github.sha }}
 
-          # Push images
-          echo "Pushing $IMAGE_ID:${{ env.VERSION }}"
+          # Push all tags to the registry
+          echo "Pushing $IMAGE_ID tags to GHCR..."
           docker push $IMAGE_ID:${{ env.VERSION }}
+          docker push $IMAGE_ID:${{ env.MINOR_VERSION }}
           docker push $IMAGE_ID:latest
           docker push $IMAGE_ID:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # -----------------------------------------------------------------------------
 # Metadata & OCI Labels
 # -----------------------------------------------------------------------------
-ARG VERSION=0.3.0
+ARG VERSION=0.3.1
 ARG BUILD_DATE=unknown
 
 LABEL org.opencontainers.image.title="ffmpeg-queue-worker-node" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "FFmpeg Worker Service (TypeScript)",
   "repository": {
     "type": "git",

--- a/src/infrastructure/ffmpeg/encoding/flags.ts
+++ b/src/infrastructure/ffmpeg/encoding/flags.ts
@@ -125,8 +125,7 @@ export function videoEncoderFlags(variant: VideoVariantMeta, sourceFrameRate?: n
       isHevc ? 'hvc1' : variant.videoCodecTag.substring(0, 4),
       '-preset',
       variant.preset,
-      '-tune',
-      'film',
+      ...(codec === 'libx264' ? ['-tune', 'film'] : []), // hotfix/20-remove-x265-film-tune #20
       ...(fpsInfo ? ['-r', fpsInfo.ffmpegFraction, '-fps_mode', 'cfr'] : []),
       ...(variant.profile ? ['-profile:v', variant.profile] : []),
       ...(variant.level ? ['-level', variant.level] : []),


### PR DESCRIPTION
## HotFix issues : #20 

**Encoding Flags Hotfix:**

* The `-tune film` flag is now only applied for `libx264` encodes, fixing an issue where it was incorrectly applied to other codecs such as `libx265`.

1. [fix: restrict film tune flag to libx264 to prevent encoding errors with x265](https://github.com/maulik-mk/ffmpeg-queue-worker-node/pull/21/changes/e2a199667bacc8ae7718f401486a873aed9269d9)

---

# **Other updates in CI**

This pull request introduces a new floating minor version tag for Docker images, simplifies the Docker image build and push logic in the CI workflow, and bumps the service version to 0.3.1. It also applies a hotfix to only use the `-tune film` flag for `libx264` encodes. The changes streamline the publishing process and improve compatibility with Docker image consumers.

**CI/CD and Docker Image Tagging Improvements:**

* The CI workflow now extracts both the exact version (e.g., `0.3.1`) and a floating minor version (e.g., `0.3`) from the `Dockerfile`, and applies both as Docker image tags, along with `latest` and the commit SHA. This allows users to pull images by minor version. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R39) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR77-R115)
* The logic for checking if a Docker image version already exists before building/pushing has been removed, ensuring that images are always built and pushed for the main branch.
* The push step now pushes all tags (`VERSION`, `MINOR_VERSION`, `latest`, and commit SHA) to the GitHub Container Registry.

1. [feat(ci): add minor version tagging and remove conditional build checks in CI workflow](https://github.com/maulik-mk/ffmpeg-queue-worker-node/pull/21/changes/c9322aad9f1ae5da48d297d42aa74681bdfc935b)

**Version Bump:**

* The service version is incremented from `0.3.0` to `0.3.1` in both `Dockerfile` and `package.json`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L173-R173) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)