### PR TITLE
[ HotFix ] : v0.3.2 fix memory leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,11 +170,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # -----------------------------------------------------------------------------
 # Metadata & OCI Labels
 # -----------------------------------------------------------------------------
-ARG VERSION=0.3.1
+ARG VERSION=0.3.2
 ARG BUILD_DATE=unknown
 
 LABEL org.opencontainers.image.title="ffmpeg-queue-worker-node" \
-      org.opencontainers.image.description="FFmpeg 7.1 (w/ VMAF) & Node.js Video Job Worker" \
+      org.opencontainers.image.description="FFmpeg 7.1 & Node.js Video Job Worker" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.authors="Maulik M. Kadeval" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "FFmpeg Worker Service (TypeScript)",
   "repository": {
     "type": "git",

--- a/src/infrastructure/ffmpeg/encoding/flags.ts
+++ b/src/infrastructure/ffmpeg/encoding/flags.ts
@@ -175,7 +175,7 @@ export function videoEncoderFlags(variant: VideoVariantMeta, sourceFrameRate?: n
 
       baseFlags.push(
          '-x265-params',
-         `pools=${config.X265_POOL_SIZE}:frame-threads=${config.X265_FRAME_THREADS}:wpp=1:pmode=1:pme=1:no-open-gop=1:scenecut=0:keyint=${gopSize}:min-keyint=${gopSize}:info=0:colorprim=${colorPrimaries}:transfer=${colorTransfer}:colormatrix=${colorMatrix}${extraHdrParams}${dvhParam}`,
+         `pools=${config.X265_POOL_SIZE}:frame-threads=${config.X265_FRAME_THREADS}:wpp=1:no-open-gop=1:scenecut=0:keyint=${gopSize}:min-keyint=${gopSize}:info=0:colorprim=${colorPrimaries}:transfer=${colorTransfer}:colormatrix=${colorMatrix}${extraHdrParams}${dvhParam}`,
          '-flags',
          '+global_header',
       );


### PR DESCRIPTION
# HotFix 
This pull request includes a minor version bump and a small update to the FFmpeg encoding flags. The main changes are updating the version to 0.3.2 across the project and removing the `pmode` and `pme` parameters from the x265 encoder flags.

Version and metadata updates:

* Bumped version from 0.3.1 to 0.3.2 in both `Dockerfile` and `package.json` for consistency across the project. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L173-R177) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)
* Updated the Docker image description to remove the mention of VMAF, reflecting the current build contents.

FFmpeg encoder flag changes:

* Removed `pmode=1` and `pme=1` from the `-x265-params` string in `videoEncoderFlags`, which may affect parallel mode and motion estimation settings for x265 encoding.